### PR TITLE
chore: apply latest CircleCI config file from orbinoid documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, standalone_release, standalone_release_replay, nexus_staging, vm_nexus_staging, pull_requests]
+    enum: [release, standalone_release, standalone_release_replay, pull_requests]
     default: pull_requests
   dry_run:
     type: boolean
@@ -32,13 +32,10 @@ parameters:
 orbs:
   slack: circleci/slack@4.2.1
   gravitee: gravitee-io/gravitee@1.0
-  # gravitee: gravitee-io/gravitee@dev:1.0.4
   secrethub: secrethub/cli@1.1.0
-  # secrethub: secrethub/cli@1.0.0
 
 workflows:
   version: 2.1
-  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
       and:
@@ -47,18 +44,18 @@ workflows:
       - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
           name: pr_secrets_resolution
-      # - gravitee/d_pr_tests_containers_qa:
-          # context: gravitee-qa
-          # name: process_pull_request_qa
-          # requires:
-            # - pr_secrets_resolution
-          # # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
-          # maven_profile_id: 'gio-dev'
-          # filters:
-            # branches:
-              # ignore:
-                # - master
-      - gravitee/d_pull_requests_ce:
+      - gravitee/d_pr_tests_containers_qa:
+          context: gravitee-qa
+          name: process_pull_request_qa
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build SNAPSHOTs ?"
+          maven_profile_id: 'gio-dev'
+          filters:
+            branches:
+              ignore:
+                - master
+      - gravitee/d_pull_requests_ee:
           name: process_pull_request
           requires:
             - pr_secrets_resolution
@@ -70,10 +67,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'medium'
-          # filters:
+            # filters:
             # branches:
-              # ignore:
-                # - master
+            # ignore:
+          # - master
   # ---
   # The 2 Workflows Below are there for the CICD Orchestrator to be able to
   # release Gravitee Kubernetes in an APIM release Process, with Docker executors instead of VMs
@@ -118,29 +115,7 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
-  # ---
-  # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
-  nexus_staging:
-    when:
-      equal: [ nexus_staging, << pipeline.parameters.gio_action >> ]
-    jobs:
-      - gravitee/d_nexus_staging_secrets:
-          context: cicd-orchestrator
-          name: nexus_staging_secrets_resolution
-      - gravitee/d_nexus_staging:
-          name: nexus_staging
-          requires:
-            - nexus_staging_secrets_resolution
-          dry_run: << pipeline.parameters.dry_run >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          # => If you are running a standalone release, your S3 Bucket name
-          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
-          # => If you are running an Orchestrated release, The Orchestrator knows how to compute the S3 Bucket name
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-          # container_gun_image_org: 'circleci'
-          # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
-          container_size: 'large'
+
   # ---
   # The 6 Workflows Below are there to perform a "Standalone Release" and "replay" a "Standalone Release" :
   # => independently of any APIM release Process, with Docker executors instead of VMs
@@ -181,59 +156,6 @@ workflows:
             - release_secrets_resolution
           dry_run: true
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-          # container_gun_image_org: 'circleci'
-          # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
-          container_size: 'large'
-
-  standalone_nexus_staging:
-    # ---
-    # Running the nexus staging makes sense only when the
-    # standalone release is being performed with dry run mode off
-    # That is to say, when the maven project is ready to be release to maven Staging
-    # ---
-    when:
-      and:
-        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
-    # ---
-    # Running the nexus staging makes sense only when the
-    # standalone release is being performed with dry run mode off
-    # That is to say, when the maven project is ready to be release to mmaven Staging
-    # Never the less, to test the CICD system, I temporarily git pushed a different configuration
-    # ---
-    # when:
-      # equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
-    jobs:
-      - gravitee/d_nexus_staging_secrets:
-          context: cicd-orchestrator
-          name: nexus_staging_secrets_resolution
-      - nexus_staging_dry_run_approval:
-          type: approval
-          requires:
-            - nexus_staging_secrets_resolution
-      - gravitee/d_standalone_nexus_staging:
-          name: standalone_nexus_staging_dry_run
-          requires:
-            - nexus_staging_dry_run_approval
-            # - nexus_staging_secrets_resolution
-          dry_run: true
-          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          maven_profile_id: "gravitee-release"
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-          # container_gun_image_org: 'circleci'
-          # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
-          container_size: 'large'
-      - gravitee/d_standalone_nexus_staging:
-          name: standalone_nexus_staging
-          requires:
-            - standalone_nexus_staging_dry_run
-            # - nexus_staging_secrets_resolution
-          dry_run: false
-          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          maven_profile_id: "gravitee-release"
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
@@ -284,76 +206,6 @@ workflows:
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
 
-  standalone_nexus_staging_replay:
-    # ---
-    # Running the nexus staging makes sense only when the
-    # standalone release is being performed with dry run mode off
-    # That is to say, when the maven project is ready to be release to maven Staging
-    # ---
-    when:
-      and:
-        - equal: [ standalone_release_replay, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
-    # ---
-    # Running the nexus staging makes sense only when the
-    # standalone release is being performed with dry run mode off
-    # That is to say, when the maven project is ready to be release to mmaven Staging
-    # Never the less, to test the CICD system, I temporarily git pushed a different configuration
-    # ---
-    # when:
-      # equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
-    jobs:
-      - gravitee/d_nexus_staging_secrets:
-          context: cicd-orchestrator
-          name: nexus_staging_secrets_resolution
-      - nexus_staging_replay_dry_run_approval:
-          type: approval
-          requires:
-            - nexus_staging_secrets_resolution
-      - gravitee/d_standalone_nexus_staging_replay:
-          name: standalone_nexus_staging_replay_dry_run
-          requires:
-            - nexus_staging_replay_dry_run_approval
-            # - nexus_staging_secrets_resolution
-          dry_run: true
-          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          maven_profile_id: "gravitee-release"
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-          gio_release_version: << pipeline.parameters.replayed_release >>
-          # container_gun_image_org: 'circleci'
-          # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
-          container_size: 'large'
-      - gravitee/d_standalone_nexus_staging_replay:
-          name: standalone_nexus_staging_replay
-          requires:
-            - standalone_nexus_staging_replay_dry_run
-            # - nexus_staging_secrets_resolution
-          dry_run: false
-          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          maven_profile_id: "gravitee-release"
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-          gio_release_version: << pipeline.parameters.replayed_release >>
-          # container_gun_image_org: 'circleci'
-          # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
-          container_size: 'large'
-
-
-  # ---
-  # CICD Workflow For APIM Orchestrated Nexus Staging, VM-based
-  vm_nexus_staging:
-    when:
-      equal: [ vm_nexus_staging, << pipeline.parameters.gio_action >> ]
-    jobs:
-      - gravitee/nexus_staging:
-          context: cicd-orchestrator
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
-          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-
-
   # ---
   # Nighlty for all CE repositories :
   # builds the SNAPSHOT, and deploys
@@ -364,14 +216,14 @@ workflows:
   nightly:
     when:
       equal: [ nightly, << pipeline.parameters.gio_action >> ]
-    # triggers:
-      # - schedule:
-          # cron: "0 0 * * *"
-          # filters:
-            # branches:
-              # only:
-                # - master
-                # - /^[0-999].[0-999].x/
+        # triggers:
+        # - schedule:
+        # cron: "0 0 * * *"
+        # filters:
+        # branches:
+        # only:
+        # - master
+      # - /^[0-999].[0-999].x/
     jobs:
       - gravitee/d_all_nightly_secrets:
           context: cicd-orchestrator

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>19.2.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Based on: https://github.com/gravitee-io/gravitee-circleci-orbinoid/blob/develop/documentation/ref-config-yml/pure-docker-executor-based/gravitee-ce/dev-repos/config.yml

Also update pom parent as stated in https://github.com/gravitee-io/kb/wiki/CICD:-The-Gravitee-APIM-Release-Process#1-orchestrated-maven-and-git-release