### PR TITLE
refactor: use common vertx proxy options factory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,17 @@ Example:
 ```
 
 
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.18.x to latest
+|1.2.x and upper                | 3.15.x to 3.17.x
+|1.1.x and upper                | 3.10.x to 3.14.x
+|1.0.x and upper                | 3.9.x
+|===
+
 == Properties
 
 [cols="^2,^2",options="header"]

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,11 @@
 
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-plugin-api.version>1.10.0</gravitee-plugin-api.version>
-        <gravitee-node-api.version>1.6.6</gravitee-node-api.version>
+        <gravitee-node-api.version>1.23.0</gravitee-node-api.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <freemarker.version>2.3.31</freemarker.version>
@@ -64,6 +65,13 @@
 
     <dependencies>
         <!-- Gravitee.io dependencies -->
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>

--- a/src/main/java/io/gravitee/policy/metricsreporter/MetricsReporterPolicy.java
+++ b/src/main/java/io/gravitee/policy/metricsreporter/MetricsReporterPolicy.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.policy.metricsreporter;
 
+import static io.gravitee.common.util.VertxProxyOptionsUtils.*;
+
 import freemarker.core.TemplateClassResolver;
 import freemarker.template.*;
 import io.gravitee.gateway.api.ExecutionContext;
@@ -32,18 +34,14 @@ import io.gravitee.policy.metricsreporter.utils.Sha1;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
-import io.vertx.core.net.ProxyOptions;
-import io.vertx.core.net.ProxyType;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -158,8 +156,17 @@ public class MetricsReporterPolicy {
         }
 
         if (configuration.isUseSystemProxy()) {
-            Environment env = context.getComponent(Environment.class);
-            options.setProxyOptions(getSystemProxyOptions(env));
+            io.gravitee.node.api.configuration.Configuration configuration = context.getComponent(
+                io.gravitee.node.api.configuration.Configuration.class
+            );
+            try {
+                setSystemProxy(options, configuration);
+            } catch (IllegalStateException e) {
+                LOGGER.warn(
+                    "Metrics reporter requires a system proxy to be defined but some configurations are missing or not well defined: {}. Ignoring proxy",
+                    e.getMessage()
+                );
+            }
         }
 
         return vertx.createHttpClient(options);
@@ -188,43 +195,6 @@ public class MetricsReporterPolicy {
         String hash = Sha1.sha1(template);
         templateLoader.putIfAbsent(hash, template);
         return templateConfiguration.getTemplate(hash);
-    }
-
-    private ProxyOptions getSystemProxyOptions(Environment environment) {
-        StringBuilder errors = new StringBuilder();
-        ProxyOptions proxyOptions = new ProxyOptions();
-
-        // System proxy must be well configured. Check that this is the case.
-        if (environment.containsProperty("system.proxy.host")) {
-            proxyOptions.setHost(environment.getProperty("system.proxy.host"));
-        } else {
-            errors.append("'system.proxy.host' ");
-        }
-
-        try {
-            proxyOptions.setPort(Integer.parseInt(Objects.requireNonNull(environment.getProperty("system.proxy.port"))));
-        } catch (Exception e) {
-            errors.append("'system.proxy.port' [").append(environment.getProperty("system.proxy.port")).append("] ");
-        }
-
-        try {
-            proxyOptions.setType(ProxyType.valueOf(environment.getProperty("system.proxy.type")));
-        } catch (Exception e) {
-            errors.append("'system.proxy.type' [").append(environment.getProperty("system.proxy.type")).append("] ");
-        }
-
-        proxyOptions.setUsername(environment.getProperty("system.proxy.username"));
-        proxyOptions.setPassword(environment.getProperty("system.proxy.password"));
-
-        if (errors.length() == 0) {
-            return proxyOptions;
-        } else {
-            LOGGER.warn(
-                "Metrics reporter requires a system proxy to be defined but some configurations are missing or not well defined: {}. Ignoring proxy",
-                errors
-            );
-            return null;
-        }
     }
 
     private HttpMethod convert(io.gravitee.common.http.HttpMethod httpMethod) {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7258

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-metrics-reporter/2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT/gravitee-policy-metrics-reporter-2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
