### PR TITLE
fix: clean pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <description>Push the request metrics to a custom endpoint</description>
 
     <properties>
-        <gravitee-apim.version>4.10.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.10.0-alpha.1</gravitee-apim.version>
         <gravitee-expression-language.version>4.2.0</gravitee-expression-language.version>
-        <gravitee-plugin-common-configurations.version>1.0.0-alpha.4</gravitee-plugin-common-configurations.version>
-        <gravitee-plugin-common-configurations-maven-plugin.version>1.0.0-alpha.3</gravitee-plugin-common-configurations-maven-plugin.version>
+        <gravitee-plugin-common-configurations.version>1.0.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations-maven-plugin.version>1.0.0</gravitee-plugin-common-configurations-maven-plugin.version>
 
         <freemarker.version>2.3.32</freemarker.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>io.gravitee.apim</groupId>
                 <artifactId>gravitee-apim-bom</artifactId>
-                <version>4.10.0-SNAPSHOT</version>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -163,18 +163,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.apim.gateway</groupId>
-            <artifactId>gravitee-apim-gateway-buffer</artifactId>
-            <version>${gravitee-apim.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.apim.gateway.handlers</groupId>
-            <artifactId>gravitee-apim-gateway-handlers-api</artifactId>
-            <version>${gravitee-apim.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>


### PR DESCRIPTION
**Description**

remove useless import, add GA version for some dependencies and remove SNAPSHOT for apim
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-clean-pom-xml-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-metrics-reporter/3.0.1-clean-pom-xml-SNAPSHOT/gravitee-policy-metrics-reporter-3.0.1-clean-pom-xml-SNAPSHOT.zip)
  <!-- Version placeholder end -->
